### PR TITLE
Account for both player's speed and angular velocity

### DIFF
--- a/Assets/Scripts/ImageEffects/Tunnelling.cs
+++ b/Assets/Scripts/ImageEffects/Tunnelling.cs
@@ -106,6 +106,7 @@ namespace Sigtrap.ImageEffects {
 			_m.SetFloat(_propFeather, feather);
 
 			_lastFwd = fwd;
+			_lastPos = pos;
 		}
 
 		void OnRenderImage(RenderTexture src, RenderTexture dest){

--- a/Assets/Scripts/ImageEffects/Tunnelling.cs
+++ b/Assets/Scripts/ImageEffects/Tunnelling.cs
@@ -23,6 +23,18 @@ namespace Sigtrap.ImageEffects {
 		[Tooltip("At/above this angular velocity, effect will be maxed out.\nDegrees per second")]
 		public float maxAngVel = 180f;
 
+		/// <summary>
+		/// Below this speed, effect will not kick in.
+		/// </summary>
+		[Tooltip("Below this speed, effect will not kick in.")]
+		public float minSpeed = 0f;
+
+		/// <summary>
+		/// At/above this speed, effect will be maxed out.
+		/// </summary>
+		[Tooltip("At/above this speed, effect will be maxed out.")]
+		public float maxSpeed = 3f;
+
 		[Header("Effect Settings")]
 		/// <summary>
 		/// Screen coverage at max angular velocity.
@@ -55,6 +67,7 @@ namespace Sigtrap.ImageEffects {
 
 		#region Misc Fields
 		private Vector3 _lastFwd;
+		private Vector3 _lastPos;
 		private Material _m;
 		#endregion
 
@@ -76,6 +89,16 @@ namespace Sigtrap.ImageEffects {
 			av = (av - minAngVel) / (maxAngVel - minAngVel);
 			av = Mathf.Clamp01(av);
 			av *= maxEffect;
+
+			Vector3 pos = refTransform.position;
+			float speed = (pos - _lastPos).magnitude / Time.deltaTime;
+
+			speed = (speed - minSpeed) / (maxSpeed - minSpeed);
+			speed = Mathf.Clamp01(speed);
+			speed *= maxEffect;
+
+			if (speed > av) 
+				av = speed;
 
 			_av = Mathf.SmoothDamp(_av, av, ref _avSlew, smoothTime);
 


### PR DESCRIPTION
Basically just takes the refTransform's current position and previous position to calculate their speed. Then it uses the same calculations/parameters as the angular velocity to determine amount of tunneling. It only takes effect if its tunneling is larger than the angular velocity's calculated tunneling.

Only tested on a Vive and the VR Toolkit's [move-in-place locomotion system](https://vrtoolkit.readme.io/docs/vrtk_moveinplace).